### PR TITLE
move example app documentation into a separate README

### DIFF
--- a/MORKExample/README.md
+++ b/MORKExample/README.md
@@ -1,0 +1,7 @@
+# MORKExample
+
+MORKExample is an example project that uses the MORK extensions to persist data to Rave.
+
+To run the example project, navigate to the MORKExample folder and run `pod install`. Open MORKExample.xcworkspace and run the project.
+
+The results are collected and serialized in the `taskViewController:didFinishWithReason:error` method of the ViewController. Once collected, these results are sent to the Patient Cloud Gateway, where they are persisted as log lines in Rave. The `odmParameters` method in the ViewController contains hardcoded data necessary for this persistence. In a real-world app, this data could be generated dynamically before being sent to the Gateway.

--- a/README.md
+++ b/README.md
@@ -73,9 +73,7 @@ The `mork_fieldDataFromResults` property can be converted to JSON and sent to th
 
 ## Example Project
 
-To run the example project, navigate to the MORKExample folder and run `pod install`. Open MORKExample.xcworkspace and run the project.
-
-The results are collected and serialized in the `taskViewController:didFinishWithReason:error` method of the ViewController.
+Documentation for `MORKExample` can be found [here](./MORKExample/README.md).
 
 # Patient Cloud / ResearchKit Integration
 


### PR DESCRIPTION
This PR splits off the MORKExample documentation into a separate README and adds some clarifying information about how the results are persisted to Rave.